### PR TITLE
Fixing windows hex2dfu.exe creation

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,7 +82,7 @@ jobs:
     inputs:
       targetType: 'inline'
       script: |
-        dotnet publish $(Build.SourcesDirectory)\source\hex2dfu.csproj -r win-x64 -p:PublishSingleFile=true --self-contained true -c Release
+        dotnet publish $(Build.SourcesDirectory)\source\hex2dfu.csproj -r win-x64 -p:PublishSingleFile=true --self-contained false -c Release
   
   - task: CopyFiles@2
     displayName: Collecting deployable artifacts


### PR DESCRIPTION
## Description

Fixing windows hex2dfu.exe creation

## Motivation and Context

- The Windows hex2dfu.exe creation was as a self contained package which does require other elements. Creating it without is fixing the issue.

## How Has This Been Tested?

ran the build, checked the exe

## Types of changes

- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
