### PR TITLE
Hex conversion update: add start address handling and parsing of non-contiguous memory maps

### DIFF
--- a/source/Hex2BinTest/DfuTest.cs
+++ b/source/Hex2BinTest/DfuTest.cs
@@ -7,6 +7,7 @@ using System;
 using Xunit;
 using nanoFramework.Tools;
 using System.Buffers.Binary;
+using System.Collections.Generic;
 
 namespace Hex2BinTest
 {
@@ -81,7 +82,7 @@ namespace Hex2BinTest
         public void TestImageElement()
         {
             // Arrange
-            ImageElement imageElement = new ImageElement() { ElementAddress = 0x12345678, Data = new byte[] { 0x12, 0x34, 0x56, 0x78, 0x90, 0xAB, 0xCD, 0xEF } };
+            ImageElement imageElement = new ImageElement() { ElementAddress = 0x12345678, Data = new List<byte>() { 0x12, 0x34, 0x56, 0x78, 0x90, 0xAB, 0xCD, 0xEF } };
             // Act
             var ser = imageElement.Serialize();
             var address = BinaryPrimitives.ReadUInt32LittleEndian(ser.AsSpan(0, 4));
@@ -89,7 +90,7 @@ namespace Hex2BinTest
             // Assert
             Assert.Equal(imageElement.ElementAddress, address);
             Assert.Equal(imageElement.ElementSize, size);
-            Assert.Equal((uint)imageElement.Data.Length, size);
+            Assert.Equal((uint)imageElement.Data.Count, size);
             Assert.Equal(0x12, ser[8]);
             Assert.Equal(0xEF, ser[15]);
         }
@@ -103,7 +104,7 @@ namespace Hex2BinTest
             dfuImage.TargetPrefix.TargetName = "Ellerbach" ;
             for (int i = 0; i < 5; i++)
             {
-                var imageElement = new ImageElement() { ElementAddress = (uint)(16 * i), Data = new byte[] { 0x12, 0x34, 0x56, 0x78, 0x90, 0xAB, 0xCD, 0xEF } };
+                var imageElement = new ImageElement() { ElementAddress = (uint)(16 * i), Data = new List<byte>() { 0x12, 0x34, 0x56, 0x78, 0x90, 0xAB, 0xCD, 0xEF } };
                 dfuImage.ImageElements.Add(imageElement);
             }
             dfuImage.TargetPrefix.NumberOfElements = (uint)dfuImage.ImageElements.Count;

--- a/source/Hex2BinTest/HexConvertTest.cs
+++ b/source/Hex2BinTest/HexConvertTest.cs
@@ -53,8 +53,9 @@ namespace Hex2BinTest
             HexFormat hex = new HexFormat(endoffile);
             // Assert
             Assert.True(hex.IsValidRecord);
+            Assert.Equal(HexFieldType.EndOfFile, hex.HexFieldType);
             Assert.Equal(0, hex.NumberOfBytes);
-            Assert.Null(hex.Data);
+            Assert.Equal(0, hex.Data.Length);
         }
 
         [Fact]

--- a/source/Hex2BinTest/HexConvertTest.cs
+++ b/source/Hex2BinTest/HexConvertTest.cs
@@ -67,7 +67,7 @@ namespace Hex2BinTest
             HexFormat hex = new HexFormat(extended);
             // Assert
             Assert.True(hex.IsValidRecord);
-            Assert.Equal(HexFieldType.ExtendedAddress, hex.HexFieldType);
+            Assert.Equal(HexFieldType.ExtendedSegmentAddress, hex.HexFieldType);
         }
 
     }

--- a/source/HexFieldType.cs
+++ b/source/HexFieldType.cs
@@ -23,21 +23,21 @@ namespace nanoFramework.Tools
         /// <summary>
         /// Extended Address
         /// </summary>
-        ExtendedAddress = 2,
+        ExtendedSegmentAddress = 2,
 
         /// <summary>
         /// Start Segment Address Record
         /// </summary>
-        StartSegmentAddressRecord = 3,
+        StartSegmentAddress = 3,
 
         /// <summary>
         /// Extended Linear Address Record
         /// </summary>
-        ExtendedLinearAddressRecord = 4,
+        ExtendedLinearAddress = 4,
 
         /// <summary>
         /// Start Linear Address Record
         /// </summary>
-        StartLinearAddressRecord = 5,
+        StartLinearAddress = 5,
     }
 }

--- a/source/ImageElement.cs
+++ b/source/ImageElement.cs
@@ -5,7 +5,7 @@
 
 using System;
 using System.Buffers.Binary;
-using System.Text;
+using System.Collections.Generic;
 
 namespace nanoFramework.Tools
 {
@@ -14,6 +14,11 @@ namespace nanoFramework.Tools
     /// </summary>
     public class ImageElement
     {
+        public ImageElement()
+        {
+            Data = new List<byte>();
+        }
+
         /// <summary>
         /// The Element Address
         /// </summary>
@@ -22,12 +27,12 @@ namespace nanoFramework.Tools
         /// <summary>
         /// The size of the Data
         /// </summary>
-        public uint ElementSize => Data != null ? (uint)Data.Length : 0;
+        public uint ElementSize => Data != null ? (uint)Data.Count : 0;
 
         /// <summary>
         /// The Data
         /// </summary>
-        public byte[] Data { get; set; }
+        public List<byte> Data { get; set; }
 
         /// <summary>
         /// Serialize the Image Element


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
<!--- Describe your changes in detail -->
<!--- Bulleted list. Full sentences. Ending with a dot. -->

- Add memory start address extraction from the source hex file to use it in the target dfu file. Prior to this, memory start address was always 0.
- Handle non-contiguous memory map. Hex file may contain multiple memory segments defined either by Extended Address record, a jump in the data record address, or both.

## Motivation and Context
- Feature enhancement.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with multiple hex files targeting STM32 platform. These are all non-zero start address and contiguous memory map with multiple Extended Linear Address records.
Non-contiguous memory map handling tested with XC8 compiler output targeting PIC platform.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
