### PR TITLE
Support ExtendedLinearAddressRecord and non-contiguous memory parsing

### DIFF
--- a/Hex2BinTest/Hex2DfuTest.cs
+++ b/Hex2BinTest/Hex2DfuTest.cs
@@ -1,0 +1,172 @@
+//
+// Copyright (c) 2021 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Buffers.Binary;
+using System.IO;
+using Xunit;
+using nanoFramework.Tools;
+
+namespace Hex2BinTest
+{
+    public class Hex2DfuTest : IDisposable
+    {
+        private readonly string _tempDir;
+
+        public Hex2DfuTest()
+        {
+            _tempDir = Path.Combine(Path.GetTempPath(), $"Hex2DfuTest_{Guid.NewGuid():N}");
+            Directory.CreateDirectory(_tempDir);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(_tempDir))
+            {
+                Directory.Delete(_tempDir, recursive: true);
+            }
+        }
+
+        private string TempHex(string name, params string[] lines)
+        {
+            string path = Path.Combine(_tempDir, name);
+            File.WriteAllLines(path, lines);
+            return path;
+        }
+
+        // DFU layout: DfuPrefix(11) + TargetPrefix(274) + ImageElements... + DfuSuffix(16)
+        private const int ElementsOffset = 11 + 274;
+
+        private static uint ReadU32LE(byte[] data, int offset)
+            => BinaryPrimitives.ReadUInt32LittleEndian(data.AsSpan(offset, 4));
+
+        [Fact]
+        public void CreateDfuFile_SingleElaRegion_ProducesOneImageElement()
+        {
+            // Arrange – one ELA record followed by 16 contiguous data bytes
+            string hexFile = TempHex("single.hex",
+                ":020000040800F2",                              // ELA → base 0x08000000
+                ":1000000000000000000000000000000000000000F0",  // 16 zero bytes at offset 0
+                ":00000001FF");
+            string dfuFile = Path.Combine(_tempDir, "single.dfu");
+
+            // Act
+            bool result = Hex2Dfu.CreateDfuFile(hexFile, dfuFile);
+
+            // Assert
+            Assert.True(result);
+            byte[] dfu = File.ReadAllBytes(dfuFile);
+
+            // NumberOfTargets in DfuPrefix is at byte 10
+            Assert.Equal(1, dfu[10]);
+
+            // ElementAddress of first element
+            uint addr = ReadU32LE(dfu, ElementsOffset);
+            Assert.Equal(0x08000000u, addr);
+
+            // ElementSize = 16
+            uint size = ReadU32LE(dfu, ElementsOffset + 4);
+            Assert.Equal(16u, size);
+        }
+
+        [Fact]
+        public void CreateDfuFile_NonContiguousMemory_ProducesTwoImageElements()
+        {
+            // Arrange – two separate ELA regions that are non-contiguous
+            string hexFile = TempHex("noncontiguous.hex",
+                ":020000040800F2",                              // ELA → base 0x08000000
+                ":1000000011111111111111111111111111111111E0",  // 16 x 0x11 at 0x08000000
+                ":020000041000EA",                              // ELA → base 0x10000000
+                ":1000000022222222222222222222222222222222D0",  // 16 x 0x22 at 0x10000000
+                ":00000001FF");
+            string dfuFile = Path.Combine(_tempDir, "noncontiguous.dfu");
+
+            // Act
+            bool result = Hex2Dfu.CreateDfuFile(hexFile, dfuFile);
+
+            // Assert
+            Assert.True(result);
+            byte[] dfu = File.ReadAllBytes(dfuFile);
+
+            // First element
+            uint addr0 = ReadU32LE(dfu, ElementsOffset);
+            uint size0 = ReadU32LE(dfu, ElementsOffset + 4);
+            Assert.Equal(0x08000000u, addr0);
+            Assert.Equal(16u, size0);
+            Assert.Equal(0x11, dfu[ElementsOffset + 8]);
+
+            // Second element starts after first element's 8-byte header + data
+            int element1Offset = ElementsOffset + 8 + (int)size0;
+            uint addr1 = ReadU32LE(dfu, element1Offset);
+            uint size1 = ReadU32LE(dfu, element1Offset + 4);
+            Assert.Equal(0x10000000u, addr1);
+            Assert.Equal(16u, size1);
+            Assert.Equal(0x22, dfu[element1Offset + 8]);
+        }
+
+        [Fact]
+        public void CreateDfuFile_ContiguousDataAcrossMultipleRecords_ProducesOneImageElement()
+        {
+            // Arrange – two sequential data records (contiguous) under a single ELA
+            string hexFile = TempHex("contiguous.hex",
+                ":020000040800F2",                              // ELA → base 0x08000000
+                ":1000000000000000000000000000000000000000F0",  // bytes 0x00–0x0F
+                ":1000100000000000000000000000000000000000E0",  // bytes 0x10–0x1F (contiguous)
+                ":00000001FF");
+            string dfuFile = Path.Combine(_tempDir, "contiguous.dfu");
+
+            // Act
+            bool result = Hex2Dfu.CreateDfuFile(hexFile, dfuFile);
+
+            // Assert
+            Assert.True(result);
+            byte[] dfu = File.ReadAllBytes(dfuFile);
+
+            uint addr = ReadU32LE(dfu, ElementsOffset);
+            uint size = ReadU32LE(dfu, ElementsOffset + 4);
+            Assert.Equal(0x08000000u, addr);
+            Assert.Equal(32u, size);
+        }
+
+        [Fact]
+        public void CreateDfuFile_InvalidHexRecord_ThrowsException()
+        {
+            // Arrange – a data record with a bad checksum
+            string hexFile = TempHex("invalid.hex",
+                ":020000040800F2",
+                ":1000000000000000000000000000000000000000FF",  // wrong CRC (should be F0)
+                ":00000001FF");
+            string dfuFile = Path.Combine(_tempDir, "invalid.dfu");
+
+            // Act & Assert
+            Assert.Throws<Exception>(() => Hex2Dfu.CreateDfuFile(hexFile, dfuFile));
+        }
+
+        [Fact]
+        public void CreateDfuFile_ElaSetsBothOffsetAndElementAddress()
+        {
+            // Arrange – verify that an ELA before any data correctly sets the element base address
+            string hexFile = TempHex("ela_addr.hex",
+                ":020000041000EA",                              // ELA → base 0x10000000
+                ":10000000AABBCCDD00112233445566778899AABB80",  // data at 0x10000000
+                ":00000001FF");
+            string dfuFile = Path.Combine(_tempDir, "ela_addr.dfu");
+
+            // Act
+            bool result = Hex2Dfu.CreateDfuFile(hexFile, dfuFile);
+
+            // Assert
+            Assert.True(result);
+            byte[] dfu = File.ReadAllBytes(dfuFile);
+
+            uint addr = ReadU32LE(dfu, ElementsOffset);
+            Assert.Equal(0x10000000u, addr);
+
+            // Verify data bytes are preserved
+            Assert.Equal(0xAA, dfu[ElementsOffset + 8]);
+            Assert.Equal(0xBB, dfu[ElementsOffset + 9]);
+        }
+    }
+}

--- a/Hex2BinTest/Hex2DfuTest.cs
+++ b/Hex2BinTest/Hex2DfuTest.cs
@@ -131,6 +131,98 @@ namespace Hex2BinTest
         }
 
         [Fact]
+        public void CreateDfuFile_TwoElaBeforeFirstData_ProducesOneNonEmptyImageElement()
+        {
+            // Regression for empty-ImageElement bug: when a second ELA record shifts
+            // offset past ElementAddress before any data is written, the flush condition
+            // fires with an empty binDestination and previously created a spurious empty element.
+            string hexFile = TempHex("two_ela.hex",
+                ":020000040800F2",                              // ELA → base 0x08000000 (sets ElementAddress + offset)
+                ":020000040801F1",                              // ELA → base 0x08010000 (offset only, elementAddressSet=true)
+                ":1000000011111111111111111111111111111111E0",  // 16 x 0x11 at 0x08010000
+                ":00000001FF");
+            string dfuFile = Path.Combine(_tempDir, "two_ela.dfu");
+
+            bool result = Hex2Dfu.CreateDfuFile(hexFile, dfuFile);
+
+            Assert.True(result);
+            byte[] dfu = File.ReadAllBytes(dfuFile);
+
+            // Exactly one element: address must be the second ELA's base (0x08010000), not the first (0x08000000)
+            uint addr = ReadU32LE(dfu, ElementsOffset);
+            Assert.Equal(0x08010000u, addr);
+
+            uint size = ReadU32LE(dfu, ElementsOffset + 4);
+            Assert.Equal(16u, size);
+            Assert.Equal(0x11, dfu[ElementsOffset + 8]);
+        }
+
+        [Fact]
+        public void CreateDfuFile_SingleElement_BinFileNameHasNoElementSuffix()
+        {
+            // Regression for double-suffix bug: with one element the name must be
+            // "{base}.bin", not "{base}_element_0.bin.bin".
+            string hexFile = TempHex("firmware.hex",
+                ":020000040800F2",
+                ":1000000000000000000000000000000000000000F0",
+                ":00000001FF");
+            string dfuFile = Path.Combine(_tempDir, "firmware.dfu");
+
+            // bin files land in the test runner's CWD (not in _tempDir) because the
+            // code builds the name from Path.GetFileNameWithoutExtension without a directory.
+            string cwd = Environment.CurrentDirectory;
+            string expectedBin = Path.Combine(cwd, "firmware.bin");
+            string wrongBin    = Path.Combine(cwd, "firmware_element_0.bin");
+            try
+            {
+                bool result = Hex2Dfu.CreateDfuFile(hexFile, dfuFile);
+
+                Assert.True(result);
+                Assert.True(File.Exists(expectedBin), $"Expected bin file not found: {expectedBin}");
+                Assert.False(File.Exists(wrongBin),   $"Unexpected suffixed bin file exists: {wrongBin}");
+            }
+            finally
+            {
+                if (File.Exists(expectedBin)) File.Delete(expectedBin);
+                if (File.Exists(wrongBin))    File.Delete(wrongBin);
+            }
+        }
+
+        [Fact]
+        public void CreateDfuFile_MultipleElements_BinFileNamesHaveSingleElementSuffix()
+        {
+            // Regression for double-suffix bug: with N>1 elements the names must be
+            // "{base}_element_{i}.bin", not "{base}_element_{i}.bin_element_{i}.bin".
+            string hexFile = TempHex("multi.hex",
+                ":020000040800F2",
+                ":1000000011111111111111111111111111111111E0",
+                ":020000041000EA",
+                ":1000000022222222222222222222222222222222D0",
+                ":00000001FF");
+            string dfuFile = Path.Combine(_tempDir, "multi.dfu");
+
+            string cwd = Environment.CurrentDirectory;
+            string expectedBin0 = Path.Combine(cwd, "multi_element_0.bin");
+            string expectedBin1 = Path.Combine(cwd, "multi_element_1.bin");
+            string wrongBin0    = Path.Combine(cwd, "multi_element_0.bin_element_0.bin");
+            try
+            {
+                bool result = Hex2Dfu.CreateDfuFile(hexFile, dfuFile);
+
+                Assert.True(result);
+                Assert.True(File.Exists(expectedBin0), $"Expected bin file not found: {expectedBin0}");
+                Assert.True(File.Exists(expectedBin1), $"Expected bin file not found: {expectedBin1}");
+                Assert.False(File.Exists(wrongBin0),   $"Unexpected double-suffix bin file exists: {wrongBin0}");
+            }
+            finally
+            {
+                if (File.Exists(expectedBin0)) File.Delete(expectedBin0);
+                if (File.Exists(expectedBin1)) File.Delete(expectedBin1);
+                if (File.Exists(wrongBin0))    File.Delete(wrongBin0);
+            }
+        }
+
+        [Fact]
         public void CreateDfuFile_InvalidHexRecord_ThrowsException()
         {
             // Arrange – a data record with a bad checksum

--- a/Hex2BinTest/HexConvertTest.cs
+++ b/Hex2BinTest/HexConvertTest.cs
@@ -70,5 +70,31 @@ namespace Hex2BinTest
             Assert.Equal(HexFieldType.ExtendedAddress, hex.HexFieldType);
         }
 
+        [Fact]
+        public void TestExtendedLinearAddressRecord()
+        {
+            // Arrange – ELA record, upper 16-bit segment = 0x0800 → base address 0x08000000
+            string ela = ":020000040800F2";
+            // Act
+            HexFormat hex = new HexFormat(ela);
+            // Assert
+            Assert.True(hex.IsValidRecord);
+            Assert.Equal(HexFieldType.ExtendedLinearAddressRecord, hex.HexFieldType);
+            Assert.Equal(2, hex.NumberOfBytes);
+            Assert.Equal(0x08, hex.Data[0]);
+            Assert.Equal(0x00, hex.Data[1]);
+        }
+
+        [Theory]
+        [InlineData(":020000040800F2")]   // ELA 0x08000000
+        [InlineData(":020000041000EA")]   // ELA 0x10000000
+        [InlineData(":020000040000FA")]   // ELA 0x00000000
+        public void TestExtendedLinearAddressRecordIsValid(string ela)
+        {
+            HexFormat hex = new HexFormat(ela);
+            Assert.True(hex.IsValidRecord);
+            Assert.Equal(HexFieldType.ExtendedLinearAddressRecord, hex.HexFieldType);
+        }
+
     }
 }

--- a/hex2dfu/Hex2Dfu.cs
+++ b/hex2dfu/Hex2Dfu.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright (c) 2021 The nanoFramework project contributors
 // See LICENSE file in the project root for full license information.
 //
@@ -58,6 +58,10 @@ namespace nanoFramework.Tools
                 {
                     offset = BinaryPrimitives.ReadUInt16BigEndian(hex.Data) << 4;
                 }
+                    else if (hex.HexFieldType == HexFieldType.ExtendedLinearAddressRecord)
+                    {
+                        offset = BinaryPrimitives.ReadUInt16BigEndian(hex.Data) << 16;
+                    }
                 else if (hex.HexFieldType == HexFieldType.EndOfFile)
                 {
                     break;

--- a/hex2dfu/Hex2Dfu.cs
+++ b/hex2dfu/Hex2Dfu.cs
@@ -7,6 +7,7 @@ using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 
 namespace nanoFramework.Tools
 {
@@ -30,77 +31,116 @@ namespace nanoFramework.Tools
         /// <returns>True if success</returns>
         public static bool CreateDfuFile(string hexFile, string dfuName, ushort vid = DefaultSTMVid, ushort pid = DefafultSTMPid, ushort fwVersion = DefaultFwVersion)
         {
-            using StreamReader reader = new StreamReader(hexFile);
-            using MemoryStream binDestination = new MemoryStream();
-            string hexLine = string.Empty;
+            uint startAddress = 0;
             long offset = 0;
             long maxSize = 0;
-            Console.WriteLine($"Converting HEX file {hexFile} to BIN format.");
-            while (reader.Peek() >= 0)
-            {
-                hexLine = reader.ReadLine();
-                HexFormat hex = new HexFormat(hexLine);
-                if (!hex.IsValidRecord)
-                {
-                    Console.WriteLine();
-                    Console.WriteLine($"ERROR: Invalid HEX record");
-                    Console.WriteLine();
-                    throw new Exception($"Error reading hex file, invalid file or CRC error");
-                }
+            List<ImageElement> imageElements = new List<ImageElement>();
+            ImageElement currentImageElement = new ImageElement();
+            bool elementAddressSet = false;
 
-                if (hex.HexFieldType == HexFieldType.Data)
+            using (StreamReader reader = new StreamReader(hexFile))
+            using (MemoryStream binDestination = new MemoryStream())
+            {
+                Console.WriteLine($"Converting HEX file {hexFile} to BIN format.");
+
+                string hexLine;
+                while ((hexLine = reader.ReadLine()) != null)
                 {
-                    binDestination.Seek(offset + hex.Address, SeekOrigin.Begin);
-                    maxSize = maxSize < offset + hex.Address ? offset + hex.Address : maxSize;
-                    binDestination.Write(hex.Data);
-                }
-                else if (hex.HexFieldType == HexFieldType.ExtendedAddress)
-                {
-                    offset = BinaryPrimitives.ReadUInt16BigEndian(hex.Data) << 4;
-                }
+                    HexFormat hex = new HexFormat(hexLine);
+
+                    if (!hex.IsValidRecord)
+                    {
+                        Console.WriteLine();
+                        Console.WriteLine($"ERROR: Invalid HEX record");
+                        Console.WriteLine();
+                        throw new Exception($"Error reading hex file, invalid file or CRC error");
+                    }
+
+                    if (hex.HexFieldType == HexFieldType.Data)
+                    {
+                        if (offset + hex.Address - currentImageElement.ElementAddress > binDestination.Length)
+                        {
+                            currentImageElement.Data = binDestination.ToArray();
+                            imageElements.Add(currentImageElement);
+                            currentImageElement = new ImageElement();
+                            currentImageElement.ElementAddress = (uint)offset + hex.Address;
+                            binDestination.SetLength(0);
+                        }
+
+                        elementAddressSet = true;
+                        binDestination.Seek(offset + hex.Address - currentImageElement.ElementAddress, SeekOrigin.Begin);
+                        maxSize = Math.Max(maxSize, offset + hex.Address - currentImageElement.ElementAddress);
+                        binDestination.Write(hex.Data);
+                    }
+                    else if (hex.HexFieldType == HexFieldType.ExtendedAddress)
+                    {
+                        if (!elementAddressSet)
+                        {
+                            startAddress = (uint)BinaryPrimitives.ReadUInt16BigEndian(hex.Data) << 4;
+                        }
+
+                        offset = BinaryPrimitives.ReadUInt16BigEndian(hex.Data) << 4;
+                    }
                     else if (hex.HexFieldType == HexFieldType.ExtendedLinearAddressRecord)
                     {
+                        if (!elementAddressSet)
+                        {
+                            currentImageElement.ElementAddress = (uint)BinaryPrimitives.ReadUInt16BigEndian(hex.Data) << 16;
+                            elementAddressSet = true;
+                        }
+
                         offset = BinaryPrimitives.ReadUInt16BigEndian(hex.Data) << 16;
                     }
-                else if (hex.HexFieldType == HexFieldType.EndOfFile)
-                {
-                    break;
+                    else if (hex.HexFieldType == HexFieldType.EndOfFile)
+                    {
+                        break;
+                    }
                 }
+
+                currentImageElement.Data = binDestination.ToArray();
+                imageElements.Add(currentImageElement);
             }
 
-            // Close the reader
-            reader.Close();
-            reader.Dispose();
-            // Save the file result and close the memory stream and the file
-            using FileStream fs = new FileStream(hexFile + ".bin", FileMode.Create);
-            Span<byte> binFile = binDestination.GetBuffer().AsSpan(0, (int)maxSize);
-            binDestination.Close();
-            binDestination.Dispose();
-            fs.Write(binFile);
-            fs.Close();
-            fs.Dispose();
+            string baseFileName = Path.GetFileNameWithoutExtension(hexFile);
 
-            DfuFile dfuFile = new();
-            DfuImage dfuImage = new();
+            for (int i = 0; i < imageElements.Count; i++)
+            {
+                ImageElement imageElement = imageElements[i];
+                string binFileName = $"{baseFileName}_element_{i}.bin";
+                if(imageElements.Count > 1)
+                    binFileName += $"_element_{i}";
+                binFileName += ".bin";
+
+                using (FileStream fs = new FileStream(binFileName, FileMode.Create))
+                {
+                    fs.Write(imageElement.Data);
+                }
+
+                Console.WriteLine($"Binary file generated: {binFileName}");
+            }
+
+            DfuFile dfuFile = new DfuFile();
+            DfuImage dfuImage = new DfuImage();
             dfuImage.TargetPrefix.TargetName = GetCleanName(dfuName);
-            ImageElement imageElement = new();
-            imageElement.Data = binFile.ToArray();
-            dfuImage.ImageElements.Add(imageElement);
+            dfuImage.ImageElements.AddRange(imageElements);
             dfuFile.DfuImages.Add(dfuImage);
             dfuFile.DfuSuffix.FirmwareVersion = fwVersion;
             dfuFile.DfuSuffix.ProductId = pid;
             dfuFile.DfuSuffix.VersionId = vid;
             var ser = dfuFile.Serialize();
-            using FileStream fdest = new FileStream(dfuName, FileMode.Create);
-            fdest.Write(ser);
-            fdest.Close();
-            fdest.Dispose();
+
+            using (FileStream fdest = new FileStream(dfuName, FileMode.Create))
+            {
+                fdest.Write(ser);
+            }
+
             Console.WriteLine();
             Console.WriteLine($"DFU generated: {dfuName}");
             Console.WriteLine($"Vendor ID: {vid.ToString("X4")}");
             Console.WriteLine($"Product ID: {pid.ToString("X4")}");
             Console.WriteLine($"Version: {fwVersion.ToString("X4")}");
             Console.WriteLine();
+
             return true;
         }
 

--- a/hex2dfu/Hex2Dfu.cs
+++ b/hex2dfu/Hex2Dfu.cs
@@ -60,8 +60,11 @@ namespace nanoFramework.Tools
                     {
                         if (offset + hex.Address - currentImageElement.ElementAddress > binDestination.Length)
                         {
-                            currentImageElement.Data = binDestination.ToArray();
-                            imageElements.Add(currentImageElement);
+                            if (binDestination.Length > 0)
+                            {
+                                currentImageElement.Data = binDestination.ToArray();
+                                imageElements.Add(currentImageElement);
+                            }
                             currentImageElement = new ImageElement();
                             currentImageElement.ElementAddress = (uint)offset + hex.Address;
                             binDestination.SetLength(0);
@@ -97,8 +100,11 @@ namespace nanoFramework.Tools
                     }
                 }
 
-                currentImageElement.Data = binDestination.ToArray();
-                imageElements.Add(currentImageElement);
+                if (binDestination.Length > 0)
+                {
+                    currentImageElement.Data = binDestination.ToArray();
+                    imageElements.Add(currentImageElement);
+                }
             }
 
             string baseFileName = Path.GetFileNameWithoutExtension(hexFile);
@@ -106,10 +112,9 @@ namespace nanoFramework.Tools
             for (int i = 0; i < imageElements.Count; i++)
             {
                 ImageElement imageElement = imageElements[i];
-                string binFileName = $"{baseFileName}_element_{i}.bin";
-                if(imageElements.Count > 1)
-                    binFileName += $"_element_{i}";
-                binFileName += ".bin";
+                string binFileName = imageElements.Count > 1
+                    ? $"{baseFileName}_element_{i}.bin"
+                    : $"{baseFileName}.bin";
 
                 using (FileStream fs = new FileStream(binFileName, FileMode.Create))
                 {


### PR DESCRIPTION
## Description
- Now the ExtendedLinearAddressRecord was supported, non-continuous region generated multiple dfu elements.
- Add unit tests to cover changes.

## Motivation and Context
I'm generating a DFU from a hex, but when I flash my device, that doesn't work. It's due to ExtendedLinearAddressRecord  was not supported and also my hex have non-contiguous memory.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Generate the DFU with St tool and compare the dfu generated with [wxHexEditor](https://www.wxhexeditor.org/)

## Screenshots<!-- (IF APPROPRIATE): -->
Left DFU generate with ST
Right DFU generated with the tool

Before modification
![image](https://github.com/nanoframework/hex2dfu/assets/9422221/4147522b-0765-4d44-99a4-c839d27c1c53)
![image](https://github.com/nanoframework/hex2dfu/assets/9422221/96de53d5-c43f-42fc-87b8-41a91109ebcd)


after modification
![image](https://github.com/nanoframework/hex2dfu/assets/9422221/d8de5368-f930-4d2d-a6b1-ebc6aa6527e9)


## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
- [ ] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [x] I have added new tests to cover my changes.

I will read this Checklist When I have free time to do this. Thank you for your understanding
